### PR TITLE
Add support for bin/download

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+err() {
+  echo >&2 -e "\e[31mE:\e[m $*"
+  exit 1
+}
+
+download_mint() {
+  local install_type=$1
+  local install_version=$2
+  local download_path=$3
+
+  if [ "$install_type" != "version" ]; then
+    err "asdf-mint supports release installs only"
+  fi
+
+  local platform
+  case "$OSTYPE" in
+    darwin*) platform="osx" ;;
+    linux*) platform="linux" ;;
+    *) err "unsupported platform" ;;
+  esac
+
+  local download_url="https://github.com/mint-lang/mint/releases/download/$install_version/mint-$install_version-$platform"
+
+  (
+    echo "∗ Downloading mint..."
+    cd "$download_path"
+    curl --silent --fail --location --remote-name "$download_url" || err "could not download mint $install_version"
+  ) || (
+    err "an error occurred downloading mint"
+  )
+}
+
+download_mint "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_DOWNLOAD_PATH"

--- a/bin/install
+++ b/bin/install
@@ -2,18 +2,19 @@
 
 set -eo pipefail
 
-fail() {
-  echo -e "\e[31mFail:\e[m $*"
+err() {
+  echo >&2 -e "\e[31mE:\e[m $*"
   exit 1
 }
 
 install_mint() {
   local install_type=$1
-  local version=$2
+  local install_version=$2
   local install_path=$3
+  local download_path=$4
 
   if [ "$install_type" != "version" ]; then
-    fail "asdf-mint supports release installs only"
+    err "asdf-mint supports release installs only"
   fi
 
   local platform
@@ -21,20 +22,33 @@ install_mint() {
   case "$OSTYPE" in
     darwin*) platform="osx" ;;
     linux*) platform="linux" ;;
-    *) fail "Unsupported platform" ;;
+    *) err "unsupported platform" ;;
   esac
 
-  local download_url="https://github.com/mint-lang/mint/releases/download/${version}/mint-${version}-${platform}"
+  if [ -z "$download_path" ]; then
+    local download_url="https://github.com/mint-lang/mint/releases/download/$install_version}/mint-$install_version-$platform"
 
-  (
-    echo "∗ Downloading and installing mint..."
-    curl --silent --fail --location --create-dirs --output "$install_path/bin/mint" "$download_url" || fail "Could not download mint $version"
-    chmod +x "$install_path/bin/mint"
-    echo "The installation was successful!"
-  ) || (
-    rm -rf "$install_path"
-    fail "An error occurred"
-  )
+    (
+      echo "∗ Downloading and installing mint..."
+      curl --silent --fail --location --create-dirs --output "$install_path/bin/mint" "$download_url" || err "Could not download mint $install_version"
+      chmod +x "$install_path/bin/mint"
+      echo "The installation was successful!"
+    ) || (
+      rm -rf "$install_path"
+      err "an error occurred downloading and installing mint"
+    )
+  else
+    (
+      echo "* Installing mint..."
+      mkdir -p "$install_path/bin"
+      cp "$download_path/mint-$install_version-$platform" "$install_path/bin/mint"
+      chmod +x "$install_path/bin/mint"
+      echo "The installation was successful!"
+    ) || (
+      rm -rf "$install_path"
+      err "an error occurred installing mint"
+    )
+  fi
 }
 
-install_mint "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"
+install_mint "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH" "$ASDF_DOWNLOAD_PATH"


### PR DESCRIPTION
Newer versions of [asdf-vm](https://asdf-vm.com) [requires](https://asdf-vm.com/#/plugins-create?id=required-scripts) [`bin/download`](https://asdf-vm.com/#/plugins-create?id=bindownload) to be present. Quoting their documentation:

> This script must download the source or binary, in the path contained in the `ASDF_DOWNLOAD_PATH` environment variable. If the downloaded source or binary is compressed, only the uncompressed source code or binary may be placed in the `ASDF_DOWNLOAD_PATH` directory.
>
> The script must exit with a status of `0` when the download is successful. If the download fails the script must exit with any non-zero exit status.
> 
> If possible the script should only place files in the `ASDF_DOWNLOAD_PATH`. If the download fails no files should be placed in the directory.
>
> If this script is not present asdf will assume that the `bin/install` script is present and will download and install the version. asdf only works without this script to support legacy plugins. All plugins must include this script, and eventually support for legacy plugins will be removed.

I did this since I intend to submit this plugin to the upstream [plugin repository](https://github.com/asdf-vm/asdf-plugins). This would allow users to just write `asdf plugin add mint` in the future. 🎉 